### PR TITLE
feat: auto-emit boolean anomaly-label column for ML-labeled datasets

### DIFF
--- a/docs/anomalies.md
+++ b/docs/anomalies.md
@@ -180,3 +180,49 @@ tsdata generate \
   --anomalies "cpu_usage:PointAnomaly(probability=0.015,magnitude=(30,50))+MissingData(mode=burst,burst_probability=0.01)" \
   --output cpu_telemetry.csv
 ```
+
+---
+
+## 🏷️ Auto-Labeled Output for ML
+
+Any metric that has anomalies configured automatically emits a **boolean ground-truth label column** alongside the metric. This turns your generated data into a ready-to-train labeled-anomaly dataset: you can compare the clean baseline against the contaminated stream to get perfect, point-level labels for benchmarking anomaly-detection models — no manual labeling required.
+
+For a metric named `cpu_usage`, the generator adds a `cpu_usage_anomaly` boolean column where a `True` marks a data point that an anomaly actually changed. A point is labeled `True` when the contaminated signal differs from the clean baseline. The comparison is NaN-aware, so `MissingData` gaps (injected `NaN`s) are flagged `True` just like `PointAnomaly` spikes.
+
+Key behaviors:
+
+*   **Naming:** The label column is always `<metric_name>_anomaly` (e.g. `cpu_usage` → `cpu_usage_anomaly`).
+*   **All anomaly types covered:** `PointAnomaly` (additive and replacement), `MissingData` (random/burst/patterned), and `ConceptDrift`. For drift, the entire drift window — transition in, hold, and restore — is labeled `True`, because every point in that regime deviates from the clean baseline.
+*   **Appears only when needed:** The label column is created only for metrics that actually have anomalies configured. Metrics with no anomalies get no label column.
+*   **Safe with normalize & plot:** The column is `bool` dtype, so `normalize()` and `plot()` — which only operate on numeric columns — skip it automatically. The labels are never rescaled or plotted.
+*   **Survives aggregation:** When you call `dg.aggregate(...)`, the label column is aggregated as a boolean OR (`max`): a coarser resample window is labeled `True` if any point within it was anomalous.
+*   **Automatic in CSV/CLI/presets:** No extra flag or config is needed. Every `tsdata generate` command (and every preset) that declares `--anomalies` automatically gains the matching `_anomaly` columns in its output CSV.
+
+```python
+from ts_data_generator import DataGen
+from ts_data_generator.utils.trends import LinearTrend
+from ts_data_generator.anomalies import PointAnomaly, MissingData
+
+dg = DataGen(seed=42)
+dg.start_datetime = "2024-01-01"
+dg.end_datetime = "2024-01-02"
+dg.to_granularity("5min")
+
+dg.add_metric(
+    name="cpu_usage",
+    trends={LinearTrend(offset=30.0, slope=0.1)},
+    anomalies=[
+        PointAnomaly(probability=0.05, mode="additive", magnitude=(10.0, 15.0)),
+        MissingData(mode="burst", burst_probability=0.01, min_length=2, max_length=4),
+    ],
+)
+
+# dg.data now includes a boolean `cpu_usage_anomaly` column — your ground-truth labels
+print(dg.data[["cpu_usage", "cpu_usage_anomaly"]].head())
+print(f"{dg.data['cpu_usage_anomaly'].sum()} labeled anomalies")
+```
+
+```bash
+# CLI: the cpu_usage_anomaly column is added to the CSV automatically — no extra flag needed
+tsdata generate --anomalies "cpu_usage:PointAnomaly(probability=0.05,magnitude=(10,15))" ...
+```

--- a/src/ts_data_generator/aggregator.py
+++ b/src/ts_data_generator/aggregator.py
@@ -61,6 +61,13 @@ def aggregate_dataframe(
         name: metric.aggregation_type.value for name, metric in metrics.items()
     }
 
+    # Auto-derived anomaly-label columns aggregate as a boolean OR (``max``):
+    # if any point in a resample window was anomalous, label the window True.
+    for name in metrics:
+        label_col = f"{name}_anomaly"
+        if label_col in data.columns:
+            agg_dict[label_col] = "max"
+
     group_keys = list(dimensions.keys())
 
     for key, multi_item in multi_items.items():

--- a/src/ts_data_generator/data_gen.py
+++ b/src/ts_data_generator/data_gen.py
@@ -547,6 +547,8 @@ class DataGen:
                 result = metric.generate(timestamps, rng=self._rng)
                 self._baselines[metric.name] = result.baseline
                 df = pd.concat([df, result.signal], axis=1)
+                if not result.labels.empty:
+                    df = pd.concat([df, result.labels], axis=1)
         return df
 
     def _build_dimensions(
@@ -576,7 +578,13 @@ class DataGen:
             chain.from_iterable(s.split(",") for s in self.multi_items.keys())
         )
 
-        column_order = ["epoch"] + dimension_names + metric_names + multi_item_names
+        column_order: list[str] = ["epoch", *dimension_names]
+        for name in metric_names:
+            column_order.append(name)
+            label_col = f"{name}_anomaly"
+            if label_col in data.columns:
+                column_order.append(label_col)
+        column_order.extend(multi_item_names)
         available = [col for col in column_order if col in data.columns]
         return data.reindex(columns=available)
 

--- a/src/ts_data_generator/schema/models.py
+++ b/src/ts_data_generator/schema/models.py
@@ -30,10 +30,14 @@ class MetricResult(NamedTuple):
     Attributes:
         signal: DataFrame with anomalies applied (trends + anomalies).
         baseline: DataFrame with trends only (no anomalies).
+        labels: DataFrame with a single boolean ``<name>_anomaly`` column
+            marking each point where the signal deviates from the clean
+            baseline. Empty when the metric has no anomalies.
     """
 
     signal: pd.DataFrame
     baseline: pd.DataFrame
+    labels: pd.DataFrame
 
 
 class Granularity(Enum):
@@ -132,7 +136,9 @@ class Metrics:
             rng: RNG instance passed through to each trend and anomaly.
 
         Returns:
-            MetricResult with .signal (trends + anomalies) and .baseline (trends only).
+            MetricResult with .signal (trends + anomalies), .baseline (trends
+            only), and .labels (boolean ``<name>_anomaly`` ground truth, empty
+            when this metric has no anomalies).
         """
         data = np.zeros(len(timestamps))
         for trend in self._trends:
@@ -142,7 +148,37 @@ class Metrics:
             data = anomaly.intervene(data, timestamps, rng=rng)
         signal_df = pd.DataFrame(data, columns=[self._name], index=timestamps)
         self._data = signal_df
-        return MetricResult(signal=signal_df, baseline=baseline_df)
+
+        labels_df = self._build_anomaly_labels(baseline_df, signal_df, timestamps)
+        return MetricResult(signal=signal_df, baseline=baseline_df, labels=labels_df)
+
+    def _build_anomaly_labels(
+        self,
+        baseline_df: pd.DataFrame,
+        signal_df: pd.DataFrame,
+        timestamps: pd.DatetimeIndex,
+    ) -> pd.DataFrame:
+        """Build the boolean ``<name>_anomaly`` ground-truth label column.
+
+        A point is labeled ``True`` when the signal deviates from the clean
+        baseline. The comparison is NaN-aware (``equal_nan=False``) so points
+        injected with ``NaN`` by ``MissingData`` are flagged, while clean points
+        are not. The column is only produced when this metric has anomalies;
+        otherwise an empty DataFrame is returned so no label column is emitted.
+
+        The label is stored as ``bool`` dtype, which keeps it out of the
+        normalizer and the plotter (both select ``number`` columns only).
+        """
+        if not self._anomalies:
+            return pd.DataFrame(index=timestamps)
+        baseline = baseline_df[self._name].to_numpy()
+        signal = signal_df[self._name].to_numpy()
+        mask = ~np.isclose(signal, baseline, equal_nan=False, atol=1e-9, rtol=1e-9)
+        return pd.DataFrame(
+            mask.astype(bool),
+            columns=[f"{self._name}_anomaly"],
+            index=timestamps,
+        )
 
     def __repr__(self) -> str:
         return str(self.to_json())

--- a/tests/test_anomalies.py
+++ b/tests/test_anomalies.py
@@ -6,10 +6,12 @@ import pytest
 
 from ts_data_generator import DataGen
 from ts_data_generator.anomalies.base import Anomaly
+from ts_data_generator.anomalies.drift import ConceptDrift, DriftSegment
 from ts_data_generator.anomalies.missing import MissingData
 from ts_data_generator.anomalies.point import PointAnomaly
 from ts_data_generator.random import DefaultRNG, SeedableRNG
 from ts_data_generator.schema.models import Granularity, Metrics
+from ts_data_generator.utils.functions import random_choice
 from ts_data_generator.utils.trends import LinearTrend
 
 
@@ -994,3 +996,331 @@ class TestConceptDriftMultiSegment:
         result2 = cd.intervene(base, timestamps, rng=rng2)
 
         assert np.array_equal(result1, result2)
+
+
+# ---------------------------------------------------------------------------
+# Auto-derived boolean anomaly-label column
+# ---------------------------------------------------------------------------
+
+def _expected_mask(signal: np.ndarray, baseline: np.ndarray) -> np.ndarray:
+    """Replicate the core label derivation for test assertions."""
+    return ~np.isclose(signal, baseline, equal_nan=False, atol=1e-9, rtol=1e-9)
+
+
+class TestMetricResultLabels:
+    def test_with_anomalies_returns_bool_label_column(self):
+        n = 500
+        timestamps = pd.date_range("2024-01-01", periods=n, freq="min")
+        trend = LinearTrend(offset=10, noise_level=0)
+        pa = PointAnomaly(probability=0.1, magnitude=5, mode="additive")
+        m = Metrics(name="test", trends={trend}, anomalies=[pa])
+
+        result = m.generate(timestamps, rng=SeedableRNG(42))
+
+        assert not result.labels.empty
+        assert "test_anomaly" in result.labels.columns
+        assert result.labels["test_anomaly"].dtype == bool
+
+    def test_without_anomalies_returns_empty_labels(self):
+        n = 100
+        timestamps = pd.date_range("2024-01-01", periods=n, freq="min")
+        m = Metrics(name="test", trends={LinearTrend(offset=10, noise_level=0)})
+
+        result = m.generate(timestamps, rng=DefaultRNG())
+
+        assert result.labels.empty
+        assert "test_anomaly" not in result.labels.columns
+
+    def test_label_true_exactly_where_signal_differs_from_baseline(self):
+        n = 1000
+        timestamps = pd.date_range("2024-01-01", periods=n, freq="min")
+        trend = LinearTrend(offset=10, noise_level=0)
+        pa = PointAnomaly(probability=0.1, magnitude=5, mode="additive")
+        m = Metrics(name="test", trends={trend}, anomalies=[pa])
+
+        result = m.generate(timestamps, rng=SeedableRNG(42))
+
+        signal = result.signal["test"].to_numpy()
+        baseline = result.baseline["test"].to_numpy()
+        label = result.labels["test_anomaly"].to_numpy()
+
+        expected = _expected_mask(signal, baseline)
+        assert np.array_equal(label, expected)
+        assert int(label.sum()) == int(expected.sum())
+        assert int(label.sum()) > 0  # at least some anomalies flagged
+
+
+class TestPointAnomalyLabels:
+    def test_additive_label_marks_changed_points(self):
+        n = 1000
+        timestamps = pd.date_range("2024-01-01", periods=n, freq="min")
+        trend = LinearTrend(offset=10, noise_level=0)
+        pa = PointAnomaly(probability=0.1, magnitude=5, mode="additive")
+        m = Metrics(name="m", trends={trend}, anomalies=[pa])
+
+        result = m.generate(timestamps, rng=SeedableRNG(42))
+        signal = result.signal["m"].to_numpy()
+        baseline = result.baseline["m"].to_numpy()
+        label = result.labels["m_anomaly"].to_numpy()
+
+        assert label.dtype == bool
+        # True exactly where the value changed (10 -> 15)
+        changed = signal != baseline
+        assert np.array_equal(label, changed)
+        assert int(label.sum()) == int(changed.sum())
+
+    def test_replacement_label_marks_changed_points(self):
+        n = 1000
+        timestamps = pd.date_range("2024-01-01", periods=n, freq="min")
+        trend = LinearTrend(offset=10, noise_level=0)
+        pa = PointAnomaly(probability=0.1, magnitude=999, mode="replacement")
+        m = Metrics(name="m", trends={trend}, anomalies=[pa])
+
+        result = m.generate(timestamps, rng=SeedableRNG(42))
+        signal = result.signal["m"].to_numpy()
+        baseline = result.baseline["m"].to_numpy()
+        label = result.labels["m_anomaly"].to_numpy()
+
+        assert label.dtype == bool
+        changed = signal != baseline
+        assert np.array_equal(label, changed)
+
+
+class TestMissingDataLabels:
+    def test_random_mode_label_marks_nan_positions(self):
+        n = 2000
+        timestamps = pd.date_range("2024-01-01", periods=n, freq="min")
+        trend = LinearTrend(offset=10, noise_level=0)
+        md = MissingData(mode="random", probability=0.05)
+        m = Metrics(name="m", trends={trend}, anomalies=[md])
+
+        result = m.generate(timestamps, rng=SeedableRNG(42))
+        signal = result.signal["m"].to_numpy()
+        label = result.labels["m_anomaly"].to_numpy()
+
+        nan_mask = np.isnan(signal)
+        # Every NaN is labeled True
+        assert np.all(label[nan_mask])
+        # Non-NaN positions are False (MissingData only injects NaN, nothing else)
+        assert not np.any(label[~nan_mask])
+        assert int(label.sum()) == int(nan_mask.sum())
+
+    def test_patterned_mode_label_marks_scheduled_timestamps(self):
+        n = 100
+        timestamps = pd.date_range("2024-01-01", periods=n, freq="h")
+
+        def schedule(ts):
+            return ts.hour % 2 == 0  # even hours
+
+        trend = LinearTrend(offset=10, noise_level=0)
+        md = MissingData(mode="patterned", schedule=schedule)
+        m = Metrics(name="m", trends={trend}, anomalies=[md])
+
+        result = m.generate(timestamps, rng=DefaultRNG())
+        label = result.labels["m_anomaly"].to_numpy()
+
+        expected = np.array([schedule(ts) for ts in timestamps])
+        assert np.array_equal(label, expected)
+
+
+class TestConceptDriftLabels:
+    def test_restore_labels_drift_window_clean_outside(self):
+        n = 300
+        base_val = 20.0
+        timestamps = pd.date_range("2024-01-01", periods=n, freq="min")
+
+        # start=50, tw=20 (50-69), hold=100 (70-169), restore tw=20 (170-189), baseline 190+
+        seg = DriftSegment(
+            start_timestamp="2024-01-01 00:50:00",
+            transition_window=1200,
+            target_mean=80.0,
+            target_std=0.0,
+            hold_duration=6000,
+            restore=True,
+        )
+        trend = LinearTrend(offset=base_val, noise_level=0)
+        m = Metrics(name="m", trends={trend}, anomalies=[ConceptDrift(segments=[seg])])
+
+        result = m.generate(timestamps, rng=SeedableRNG(42))
+        label = result.labels["m_anomaly"].to_numpy()
+
+        # Before drift: clean baseline -> all False
+        assert not np.any(label[:50])
+        # Hold region: replaced with target (80 != 20) -> all True
+        assert np.all(label[70:170])
+        # After restore completes: back to baseline -> all False
+        assert not np.any(label[190:])
+        # Transition + restore regions contain anomalies (not all False)
+        assert np.any(label[50:190])
+
+    def test_no_restore_labels_hold_then_clean_after(self):
+        n = 100
+        timestamps = pd.date_range("2024-01-01", periods=n, freq="min")
+
+        # start=10, tw=5 (10-14), hold=20 (15-34), no restore, baseline 35+
+        seg = DriftSegment(
+            start_timestamp="2024-01-01 00:10:00",
+            transition_window=300,
+            target_mean=99.0,
+            target_std=0.0,
+            hold_duration=1200,
+            restore=False,
+        )
+        trend = LinearTrend(offset=0.0, noise_level=0)
+        m = Metrics(name="m", trends={trend}, anomalies=[ConceptDrift(segments=[seg])])
+
+        result = m.generate(timestamps, rng=SeedableRNG(42))
+        label = result.labels["m_anomaly"].to_numpy()
+
+        # Before drift: clean -> False
+        assert not np.any(label[:10])
+        # Hold region: target 99 != 0 -> True
+        assert np.all(label[15:35])
+        # After segment: back to baseline -> False
+        assert not np.any(label[35:])
+        # Transition has some True
+        assert np.any(label[10:15])
+
+
+class TestStackedAnomalyLabels:
+    def test_stacked_labels_are_union_of_masks(self):
+        n = 2000
+        timestamps = pd.date_range("2024-01-01", periods=n, freq="min")
+        trend = LinearTrend(offset=10, noise_level=0)
+
+        pa = PointAnomaly(probability=0.1, magnitude=100, mode="replacement")
+        md = MissingData(mode="random", probability=0.1)
+        m = Metrics(name="m", trends={trend}, anomalies=[pa, md])
+
+        result = m.generate(timestamps, rng=SeedableRNG(42))
+        signal = result.signal["m"].to_numpy()
+        baseline = result.baseline["m"].to_numpy()
+        label = result.labels["m_anomaly"].to_numpy()
+
+        # Union: True wherever either anomaly touched (derived from the diff)
+        expected = _expected_mask(signal, baseline)
+        assert np.array_equal(label, expected)
+        # Union should be at least as large as each individual contribution
+        nan_mask = np.isnan(signal)
+        assert int(label.sum()) >= int(nan_mask.sum())
+
+
+class TestDataGenAnomalyLabelColumn:
+    def test_label_column_present_only_for_anomalous_metrics(self):
+        dg = DataGen(
+            start_datetime="2024-01-01",
+            end_datetime="2024-01-03",
+            granularity=Granularity.HOURLY,
+            seed=42,
+        )
+        dg.add_metric(
+            "cpu",
+            {LinearTrend(offset=10, noise_level=0)},
+            anomalies=[PointAnomaly(probability=0.5, magnitude=5, mode="additive")],
+        )
+        dg.add_metric("clean", {LinearTrend(offset=10, noise_level=0)})
+
+        assert "cpu_anomaly" in dg.data.columns
+        assert "clean_anomaly" not in dg.data.columns
+
+    def test_label_column_is_bool_dtype(self):
+        dg = DataGen(
+            start_datetime="2024-01-01",
+            end_datetime="2024-01-03",
+            granularity=Granularity.HOURLY,
+            seed=42,
+        )
+        dg.add_metric(
+            "cpu",
+            {LinearTrend(offset=10, noise_level=0)},
+            anomalies=[PointAnomaly(probability=0.5, magnitude=5, mode="additive")],
+        )
+        assert dg.data["cpu_anomaly"].dtype == bool
+
+    def test_label_column_positioned_right_after_metric(self):
+        dg = DataGen(
+            start_datetime="2024-01-01",
+            end_datetime="2024-01-03",
+            granularity=Granularity.HOURLY,
+            seed=42,
+        )
+        dg.add_metric(
+            "cpu",
+            {LinearTrend(offset=10, noise_level=0)},
+            anomalies=[PointAnomaly(probability=0.5, magnitude=5, mode="additive")],
+        )
+        cols = list(dg.data.columns)
+        assert "cpu" in cols
+        assert "cpu_anomaly" in cols
+        assert cols.index("cpu_anomaly") == cols.index("cpu") + 1
+
+    def test_same_seed_produces_identical_label_columns(self):
+        def build():
+            dg = DataGen(
+                start_datetime="2024-01-01",
+                end_datetime="2024-01-02",
+                granularity=Granularity.HOURLY,
+                seed=42,
+            )
+            dg.add_metric(
+                "cpu",
+                {LinearTrend(offset=10, noise_level=0)},
+                anomalies=[PointAnomaly(probability=0.3, magnitude=5, mode="additive")],
+            )
+            return dg.data["cpu_anomaly"].to_numpy()
+
+        assert np.array_equal(build(), build())
+
+
+class TestAnomalyLabelAggregation:
+    def test_label_survives_aggregation_as_or(self):
+        dg = DataGen(
+            start_datetime="2024-01-01",
+            end_datetime="2024-01-03",
+            granularity=Granularity.HOURLY,
+            seed=42,
+        )
+        dg.add_dimension("region", random_choice(["US", "EU"]))
+        dg.add_metric(
+            "cpu",
+            {LinearTrend(offset=10, noise_level=0)},
+            anomalies=[PointAnomaly(probability=0.3, magnitude=5, mode="additive")],
+        )
+
+        raw = dg.data
+        agg = dg.aggregate("D")
+
+        assert "cpu_anomaly" in agg.columns
+        assert agg["cpu_anomaly"].dtype == bool
+        # OR semantics: aggregated True count cannot exceed raw True count
+        assert int(agg["cpu_anomaly"].sum()) <= int(raw["cpu_anomaly"].sum())
+
+        # OR semantics, exactly: a (region, day) group is True iff any raw row
+        # in that group is True.
+        raw_reset = raw.reset_index().rename(columns={"index": "ts"})
+        raw_reset["day"] = raw_reset["ts"].dt.floor("D")
+        manual_any = raw_reset.groupby(["region", "day"])["cpu_anomaly"].any()
+        assert int(agg["cpu_anomaly"].sum()) == int(manual_any.sum())
+
+
+class TestAnomalyLabelNormalization:
+    def test_normalizer_skips_bool_label_column(self):
+        dg = DataGen(
+            start_datetime="2024-01-01",
+            end_datetime="2024-01-03",
+            granularity=Granularity.HOURLY,
+            seed=42,
+        )
+        dg.add_metric(
+            "cpu",
+            {LinearTrend(offset=10, noise_level=0)},
+            anomalies=[PointAnomaly(probability=0.3, magnitude=5, mode="additive")],
+        )
+
+        true_count_before = int(dg.data["cpu_anomaly"].sum())
+        dg.normalize("min-max")
+
+        # Label untouched: still bool, same values
+        assert dg.data["cpu_anomaly"].dtype == bool
+        assert set(dg.data["cpu_anomaly"].unique()).issubset({True, False})
+        assert int(dg.data["cpu_anomaly"].sum()) == true_count_before


### PR DESCRIPTION
Whenever a metric has anomalies, automatically add a `<metric_name>_anomaly` boolean column marking each data point that deviates from the clean baseline. This turns every generated dataset with anomalies into a ready-to-train labeled anomaly dataset for ML use cases.

The label is derived by diffing the contaminated signal against the clean baseline (NaN-aware comparison), so it requires no changes to the anomaly classes and generalizes to any future anomaly type. The column is stored as `bool` dtype, which keeps it out of the normalizer and plotter (both select numeric columns only) without extra guards. Aggregation keeps the label via boolean OR (`max`) so it survives resampling.

- MetricResult gains a `labels` field; Metrics.generate() builds the label
- data_gen interleaves `<name>_anomaly` right after its metric
- aggregator aggregates the label as `max` (boolean OR)
- only emitted when a metric actually has anomalies
- 16 new tests covering point/missing/drift/stacked labels, dtype, ordering, determinism, aggregation-as-OR, and normalization-skip